### PR TITLE
Updated create-instance.yml to respect and use the env variable.

### DIFF
--- a/tasks/create-instance.yml
+++ b/tasks/create-instance.yml
@@ -12,13 +12,13 @@
     region: "{{ aws_region }}"
     assign_public_ip: yes
     instance_tags:
-      Env: admin
+      Env: "{{ env }}"
       Stack: vpn
       Layer: vpn_primary
       Name: vpn_primary
     exact_count: 1
     count_tag:
-      Env: admin
+      Env: "{{ env }}"
       Stack: vpn
       Layer: vpn_primary
       Name: vpn_primary


### PR DESCRIPTION
This is helpful in the case of multiple VPC per region/account. 

This role could use more refining- there are a lot of hardcoded values that we could have flow from variables, but I think this is the simplest change to get it to work.

@reactiveops/technical-team-members 