### PR TITLE
Support multiple VPNs per account in separate envs

### DIFF
--- a/tasks/admin-security-group.yml
+++ b/tasks/admin-security-group.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: admin security groups
+- name: VPN security groups
   ec2_group:
     state: present
     name: "{{env}}_{{item.key}}"
@@ -13,7 +13,7 @@
   register: sgs
   vars:
     nat_all_traffic:
-      - {group_name: "admin_nat", proto: 'tcp',   from_port: '1',   to_port: '65535'} # all tcp traffic to NAT
+      - {group_name: "{{ env }}_nat", proto: 'tcp',   from_port: '1',   to_port: '65535'} # all tcp traffic to NAT
     vpc_all_traffic:
       - {cidr_ip: "{{aws_vpc_cidr}}", proto: 'tcp',   from_port: '1',   to_port: '65535'} # all tcp traffic
       - {cidr_ip: "{{aws_vpc_cidr}}", proto: 'udp',   from_port: '1',   to_port: '65535'} # all udp traffic
@@ -37,23 +37,23 @@
           - "{{world_http_https}}"
       presentation:
         ingress:
-          - {group_name: "admin_vpn", proto: tcp, from_port: '443', to_port: '443'} # https from vpn
+          - {group_name: "{{ env }}_vpn", proto: tcp, from_port: '443', to_port: '443'} # https from vpn
         egress:
           - "{{vpc_all_traffic}}"
       application:
         ingress:
-          - {group_name: "{{env}}_presentation", proto: tcp, from_port: '80',  to_port: '80'}   # http from presentation
-          - {group_name: "{{env}}_presentation", proto: tcp, from_port: '443', to_port: '443'}  # https from presentation
-          - {group_name: "admin_application",    proto: tcp, from_port: '22',  to_port: '22'}   # ssh from admin hosts
-          - {group_name: "admin_vpn",            proto: tcp, from_port: '22',  to_port: '22'}   # ssh from vpn
-          - {group_name: "admin_vpn",            proto: tcp, from_port: '443', to_port: '443'}
+          - {group_name: "{{env}}_presentation",  proto: tcp, from_port: '80',  to_port: '80'}   # http from presentation
+          - {group_name: "{{env}}_presentation",  proto: tcp, from_port: '443', to_port: '443'}  # https from presentation
+          - {group_name: "{{ env }}_application", proto: tcp, from_port: '22',  to_port: '22'}   # ssh from env hosts
+          - {group_name: "{{ env }}_vpn",         proto: tcp, from_port: '22',  to_port: '22'}   # ssh from vpn
+          - {group_name: "{{ env }}_vpn",         proto: tcp, from_port: '443', to_port: '443'}
         egress: []
       data:
         ingress: []
         egress:
           - "{{vpc_all_traffic}}"
 
-- name: tag admin security groups
+- name: tag VPN security groups
   local_action:
     module: ec2_tag
     resource: "{{item.group_id}}"

--- a/tasks/create-instance.yml
+++ b/tasks/create-instance.yml
@@ -15,13 +15,12 @@
       Env: "{{ env }}"
       Stack: vpn
       Layer: vpn_primary
-      Name: vpn_primary
+      Name: "{{ env }}_vpn_primary"
     exact_count: 1
     count_tag:
       Env: "{{ env }}"
       Stack: vpn
       Layer: vpn_primary
-      Name: vpn_primary
   register: ec2
 
 - set_fact:

--- a/tasks/create-instance.yml
+++ b/tasks/create-instance.yml
@@ -5,7 +5,7 @@
     vpc_subnet_id: "{{ public_az1 }}"
     key_name: "{{ aws_key_name }}"
     instance_profile_name: "{{env}}_vpn"
-    group_id: "{{ admin_vpn }}"
+    group: "{{ env }}_vpn"
     instance_type: t2.small
     image: "{{ default_ami }}"
     wait: true

--- a/tasks/create-instance.yml
+++ b/tasks/create-instance.yml
@@ -12,13 +12,13 @@
     region: "{{ aws_region }}"
     assign_public_ip: yes
     instance_tags:
-      Env: admin
+      Env: "{{ env }}"
       Stack: vpn
       Layer: vpn_primary
       Name: vpn_primary
     exact_count: 1
     count_tag:
-      Env: admin
+      Env: "{{ env }}"
       Stack: vpn
       Layer: vpn_primary
       Name: vpn_primary


### PR DESCRIPTION
Based on #4 

Use `env` where needed to support multiple VPN installations in a single account. 

@reactiveops/technical-team-members 